### PR TITLE
Bugfix - relHooks is sometimes undefined (closes #9)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -419,7 +419,9 @@ kalamata.expose = function(model, _opts_) {
             if(relHooks) {
                 var relObj = {};
                 relObj[r] = function(qb) {
-                    runHooks(relHooks.before.getRelated, [req, res, qb]);
+                    if(relHooks){
+                        runHooks(relHooks.before.getRelated, [req, res, qb]);
+                    }
                 };
                 relArray.push(relObj);
             } else {


### PR DESCRIPTION
#9 - when loading nested relations, relHooks is used in a dynamic function - but sometimes, when that dynamic function is called, relHooks is undefined and everything breaks.

I'm not sure what the cause of this is because of my lack of deep understanding of Kalamata, but I patched it and was able to restore functionality.

@mikec would appreciate you taking a look at this!